### PR TITLE
Allow setting of GDB ip

### DIFF
--- a/avatar2/targets/gdb_target.py
+++ b/avatar2/targets/gdb_target.py
@@ -4,7 +4,8 @@ from avatar2.protocols.gdb import GDBProtocol
 
 class GDBTarget(Target):
     def __init__(self, avatar,
-                 gdb_executable='gdb', gdb_additional_args=None, gdb_port=3333,
+                 gdb_executable='gdb', gdb_additional_args=None, 
+                 gdb_ip='127.0.0.1', gdb_port=3333,
                  gdb_serial_device='/dev/ttyACM0',
                  gdb_serial_baud_rate=38400,
                  gdb_serial_parity='none',
@@ -16,6 +17,7 @@ class GDBTarget(Target):
 
         self.gdb_executable = gdb_executable
         self.gdb_additional_args = gdb_additional_args if gdb_additional_args else []
+        self.gdb_ip = gdb_ip
         self.gdb_port = gdb_port
         self.gdb_serial_device = gdb_serial_device
         self.gdb_serial_baud_rate = gdb_serial_baud_rate
@@ -30,7 +32,7 @@ class GDBTarget(Target):
                           avatar=self.avatar, origin=self)
 
         if not self._serial:
-            if gdb.remote_connect(port=self.gdb_port):
+            if gdb.remote_connect(ip=self.gdb_ip, port=self.gdb_port):
                 self.log.info("Connected to Target")
             else:
                 self.log.warning("Connecting failed")


### PR DESCRIPTION
By default GDB instances are expected to only ever connect to the local machine '127.0.0.1'. The functionality exists within GDBTarget but isn't readily exposed to an end user.

I've just exposed it with a slight modification of the gdb_target.py source file.