### PR TITLE
Make AvatarPeripheral's custom read and write handlers pass the requested offset

### DIFF
--- a/avatar2/peripherals/avatar_peripheral.py
+++ b/avatar2/peripherals/avatar_peripheral.py
@@ -21,21 +21,21 @@ class AvatarPeripheral(object):
         intervals = self.write_handler[offset:offset + size - 1]
         if intervals == set():
             raise Exception("No write handler for peripheral %s at offset %d \
-                            (0x%x)" % (self.name, address - self.address,
+                            (0x%x)" % (self.name, offset,
                                        address))
         if len(intervals) > 1:
             raise Exception("Multiple write handler for peripheral %s\
-                            at offset %d" % (self.name, self.address - address))
-        return intervals.pop().data(size, value)
+                            at offset %d" % (self.name, offset))
+        return intervals.pop().data(offset, size, value)
 
     def read_memory(self, address, size):
         offset = address - self.address
         intervals = self.read_handler[offset:offset + size - 1]
         if intervals == set():
             raise Exception("No read handler for peripheral %s at offset %d \
-                            (0x%x)" % (self.name, address - self.address,
+                            (0x%x)" % (self.name, offset,
                                        address))
         if len(intervals) > 1:
             raise Exception("Multiple read handler for peripheral %s\
-                            at offset %d" % (self.name, self.address - address))
-        return intervals.pop().data(size)
+                            at offset %d" % (self.name, offset))
+        return intervals.pop().data(offset, size)

--- a/avatar2/peripherals/nucleo_usart.py
+++ b/avatar2/peripherals/nucleo_usart.py
@@ -9,7 +9,7 @@ SR_TC = 0x40
 
 
 class NucleoRTC(AvatarPeripheral):
-    def nop_read(self, size):
+    def nop_read(self, offset, size):
         return 0x00
 
     def __init__(self, name, address, size, **kwargs):
@@ -18,10 +18,10 @@ class NucleoRTC(AvatarPeripheral):
 
 
 class NucleoTIM(AvatarPeripheral):
-    def nop_read(self, size):
+    def nop_read(self, offset, size):
         return 0x00
 
-    def nop_write(self, size, value):
+    def nop_write(self, offset, size, value):
         return True
 
     def __init__(self, name, address, size, **kwargs):
@@ -31,13 +31,13 @@ class NucleoTIM(AvatarPeripheral):
 
 
 class NucleoUSART(AvatarPeripheral, Thread):
-    def read_status_register(self, size):
+    def read_status_register(self, offset, size):
         self.lock.acquire(True)
         ret = self.status_register
         self.lock.release()
         return ret
 
-    def read_data_register(self, size):
+    def read_data_register(self, offset, size):
         self.lock.acquire(True)
         ret = self.data_buf[0]
         self.data_buf = self.data_buf[1:]
@@ -46,16 +46,16 @@ class NucleoUSART(AvatarPeripheral, Thread):
         self.lock.release()
         return ret
 
-    def write_data_register(self, size, value):
+    def write_data_register(self, offset, size, value):
         if self.connected:
             self.conn.send(bytes((chr(value).encode('utf-8'))))
 
         return True
 
-    def nop_read(self, size):
+    def nop_read(self, offset, size):
         return 0x00
 
-    def nop_write(self, size, value):
+    def nop_write(self, offset, size, value):
         return True
 
     def __init__(self, name, address, size, nucleo_usart_port=5656, **kwargs):

--- a/handbook/0x03_memory.md
+++ b/handbook/0x03_memory.md
@@ -99,12 +99,12 @@ from avatar2 import *
 
 class HelloWorldPeripheral(AvatarPeripheral):
 
-    def hw_read(self, size):         
+    def hw_read(self, offset, size):         
         ret = self.hello_world[:size]
         self.hello_world = self.hello_world[size:] + self.hello_world[:size]
         return ret
 
-    def nop_write(self, size, value):
+    def nop_write(self, offset, size, value):
         return True    
 
     def __init__(self, name, address, size, **kwargs):


### PR DESCRIPTION
This can be very useful for an emulated peripheral to do sensible things with a read/write request to a certain address, without having to define separate methods for each memory range.

The absolute requested address can be obtained in a read or write handler with `self.address + offset`.