### PR TITLE
Some features added (get_symbol, file, download)

### DIFF
--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -779,7 +779,7 @@ class GDBProtocol(object):
             regex = re.compile("(0x[0-9a-f]*)[ .]")
             resp = regex.findall(resp)
             if len(resp) == 1:
-                resp = long(resp[0], 16)
+                resp = int(resp[0], 16)
             else:
                 resp = -1
                 ret = False

--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -744,6 +744,16 @@ class GDBProtocol(object):
             resp)
         return ret
 
+    def file(self, elf=''):
+        """Load an ELF file
+        :returns: True on success"""
+        ret, resp = self._sync_request(["-file-exec-and-symbols", elf], GDB_PROT_DONE)
+
+        self.log.debug(
+            "Attempted to load elf file. Received response: %s" %
+            resp)
+        return ret
+
     def set_endianness(self, endianness='little'):
         req = ['-gdb-set', 'endian', '%s' % endianness]
         ret, resp = self._sync_request(req, GDB_PROT_DONE)

--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -744,7 +744,7 @@ class GDBProtocol(object):
             resp)
         return ret
 
-    def file(self, elf=''):
+    def set_file(self, elf=''):
         """Load an ELF file
         :returns: True on success"""
         ret, resp = self._sync_request(["-file-exec-and-symbols", elf], GDB_PROT_DONE)

--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -283,7 +283,7 @@ class GDBProtocol(object):
             self._gdbmi.exit()
             self._gdbmi = None
 
-    def _sync_request(self, request, rexpect):
+    def _sync_request(self, request, rexpect, timeout=5):
         """ Generic method to send a syncronized request
 
         :param request: the request as list
@@ -300,7 +300,7 @@ class GDBProtocol(object):
 
         self._gdbmi.write(req, read_response=False, timeout_sec=0)
         try:
-            response = self._communicator.get_sync_response(token)
+            response = self._communicator.get_sync_response(token, timeout=timeout)
             ret = True if response['message'] == rexpect else False
         except:
             response = None

--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -754,6 +754,16 @@ class GDBProtocol(object):
             resp)
         return ret
 
+    def download(self):
+        """Download code to target
+        :returns: True on success"""
+        ret, resp = self._sync_request(["-target-download"], GDB_PROT_DONE, timeout=60)
+
+        self.log.debug(
+            "Attempted to download code to target. Received response: %s" %
+            resp)
+        return ret
+
     def set_endianness(self, endianness='little'):
         req = ['-gdb-set', 'endian', '%s' % endianness]
         ret, resp = self._sync_request(req, GDB_PROT_DONE)

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -273,7 +273,9 @@ class Target(object):
         Continues the execution of the target
         :param blocking: if True, block until the target is RUNNING
         """
-        return self.protocols.execution.file(elf)
+        if not hasattr(self.protocols.execution, 'set_file'):
+            self.log.error('Protocol "' + type(self.protocols.execution).__name__ + '" does not support "set_file"')
+            return False
 
         return self.protocols.execution.set_file(elf)
 
@@ -284,6 +286,10 @@ class Target(object):
         Continues the execution of the target
         :param blocking: if True, block until the target is RUNNING
         """
+        if not hasattr(self.protocols.execution, 'download'):
+            self.log.error('Protocol "' + type(self.protocols.execution).__name__ + '" does not support "download"')
+            return False
+
         return self.protocols.execution.download()
 
     @watch('TargetGetSymbol')

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -266,15 +266,16 @@ class Target(object):
         """
         return self.protocols.execution.step()
 
-    @watch('File')
+    @watch('TargetSetFile')
     @action_valid_decorator_factory(TargetStates.STOPPED, 'execution')
-    def file(self, elf, blocking=True):
+    def set_file(self, elf):
         """
         Continues the execution of the target
         :param blocking: if True, block until the target is RUNNING
         """
         return self.protocols.execution.file(elf)
 
+        return self.protocols.execution.set_file(elf)
 
     @watch('TargetDownload')
     @action_valid_decorator_factory(TargetStates.STOPPED, 'execution')

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -266,6 +266,17 @@ class Target(object):
         """
         return self.protocols.execution.step()
 
+    @watch('TargetGetSymbol')
+    @action_valid_decorator_factory(TargetStates.STOPPED, 'memory')
+    def get_symbol(self, symbol):
+        """
+        Get the address of a symbol
+
+        :param symbol:    The name of a symbol whose address is wanted
+        :returns:         (True, Address) on success else False
+        """
+        return self.protocols.memory.get_symbol(symbol)
+
     @watch('TargetWriteMemory')
     @action_valid_decorator_factory(TargetStates.STOPPED, 'memory')
     def write_memory(self, address, size, value, num_words=1, raw=False):

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -266,6 +266,16 @@ class Target(object):
         """
         return self.protocols.execution.step()
 
+    @watch('File')
+    @action_valid_decorator_factory(TargetStates.STOPPED, 'execution')
+    def file(self, elf, blocking=True):
+        """
+        Continues the execution of the target
+        :param blocking: if True, block until the target is RUNNING
+        """
+        return self.protocols.execution.file(elf)
+
+
     @watch('TargetGetSymbol')
     @action_valid_decorator_factory(TargetStates.STOPPED, 'memory')
     def get_symbol(self, symbol):

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -270,8 +270,10 @@ class Target(object):
     @action_valid_decorator_factory(TargetStates.STOPPED, 'execution')
     def set_file(self, elf):
         """
-        Continues the execution of the target
-        :param blocking: if True, block until the target is RUNNING
+        Load an ELF file
+
+        :param elf: ELF file to load
+        :returns: True on success else False
         """
         if not hasattr(self.protocols.execution, 'set_file'):
             self.log.error('Protocol "' + type(self.protocols.execution).__name__ + '" does not support "set_file"')
@@ -281,10 +283,11 @@ class Target(object):
 
     @watch('TargetDownload')
     @action_valid_decorator_factory(TargetStates.STOPPED, 'execution')
-    def download(self, blocking=True):
+    def download(self):
         """
-        Continues the execution of the target
-        :param blocking: if True, block until the target is RUNNING
+        Download the loaded code to the Target
+
+        :returns: True on success else False
         """
         if not hasattr(self.protocols.execution, 'download'):
             self.log.error('Protocol "' + type(self.protocols.execution).__name__ + '" does not support "download"')

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -276,6 +276,15 @@ class Target(object):
         return self.protocols.execution.file(elf)
 
 
+    @watch('TargetDownload')
+    @action_valid_decorator_factory(TargetStates.STOPPED, 'execution')
+    def download(self, blocking=True):
+        """
+        Continues the execution of the target
+        :param blocking: if True, block until the target is RUNNING
+        """
+        return self.protocols.execution.download()
+
     @watch('TargetGetSymbol')
     @action_valid_decorator_factory(TargetStates.STOPPED, 'memory')
     def get_symbol(self, symbol):

--- a/avatar2/watchmen.py
+++ b/avatar2/watchmen.py
@@ -26,6 +26,7 @@ class WatchedTypes(object):
         'TargetRemovebreakpoint',
         'TargetWait',
         'File',
+        'TargetDownload'
     ]
 
     def __init__(self):

--- a/avatar2/watchmen.py
+++ b/avatar2/watchmen.py
@@ -25,7 +25,7 @@ class WatchedTypes(object):
         'TargetSetWatchPoint',
         'TargetRemovebreakpoint',
         'TargetWait',
-        'File',
+        'TargetSetFile',
         'TargetDownload'
     ]
 

--- a/avatar2/watchmen.py
+++ b/avatar2/watchmen.py
@@ -16,6 +16,7 @@ class WatchedTypes(object):
         'TargetCont',
         'TargetStop',
         'TargetStep',
+        'TargetGetSymbol',
         'TargetWriteMemory',
         'TargetReadMemory',
         'TargetRegisterWrite',

--- a/avatar2/watchmen.py
+++ b/avatar2/watchmen.py
@@ -24,7 +24,8 @@ class WatchedTypes(object):
         'TargetSetBreakpoint',
         'TargetSetWatchPoint',
         'TargetRemovebreakpoint',
-        'TargetWait'
+        'TargetWait',
+        'File',
     ]
 
     def __init__(self):


### PR DESCRIPTION
For my purposes (a HW testing system) I need to load an ELF file and download it to the target (via OpenOCD + GDB), so I have added the required code to Avatar2.

So I have added:

- Target.get_symbol to get the address of a symbol
- Target.file/GDBProtocol.file to load the ELF file (-file-exec-and-symbols GDB command)
- Target.download/GDBProtocol.download to download the FW to the device (-target-download GDB command)
