### PR TITLE
Do not register SIGINT handler if we are not running from main thread

### DIFF
--- a/avatar2/avatar2.py
+++ b/avatar2/avatar2.py
@@ -36,10 +36,13 @@ class Avatar(Thread):
     def __init__(self, arch=ARM, cpu_model=None, output_directory=None):
         super(Avatar, self).__init__()
 
-        
         self.shutdowned = False
-        signal.signal(signal.SIGINT, self.sigint_wrapper)
-        self.sigint_handler = self.shutdown
+        try:
+            signal.signal(signal.SIGINT, self.sigint_wrapper)
+            self.sigint_handler = self.shutdown
+        except ValueError:
+            # Cannot register SIGINT handler: we are not in main thread. Do not care about it.
+            pass
         atexit.register(self.shutdown)
 
         self.watchmen = Watchmen(self)


### PR DESCRIPTION
I am using avatar2 inside an [openhtf](https://github.com/google/openhtf) plug, that runs in its own threads, which makes it not possible to register signal handlers.