### PR TITLE
Make enum34 dependency conditional on python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'parse',
         'configparser',
         'npyscreen',
-        'enum34',
+        'enum34;python_version<"3.4"',
         'unicorn',
         'bitstring',
 	'pylink-square',


### PR DESCRIPTION
I don't know why this situation pops up for me sometimes but not others, but I have found that in some of the weird import paths that pip may give itself in the middle of install processes, enum34 may take precedence over the stdlib enum, which is a problem when you're running python 3.6 and the stdlib expects enum to have the newer features.

This PR makes the enum34 dependency only happen when the python interpreter is older than 3.4.