### PR TITLE
Fixed Race Condition occuring in Intro Example

### DIFF
--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -265,7 +265,7 @@ class Target(object):
 
     @watch('TargetCont')
     @action_valid_decorator_factory(TargetStates.STOPPED, 'execution')
-    @synchronize_state(TargetStates.RUNNING)
+    @synchronize_state(TargetStates.RUNNING, TargetStates.EXITED)
     def cont(self, blocking=True):
         """
         Continues the execution of the target

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -65,6 +65,7 @@ def synchronize_state(*states, **kwargs):
                     if message.origin == self:
                         if message.state == state:
                             state_reached.set()
+                            avatar.watchmen.remove_watchman('UpdateState', w)
                         elif message.state == TargetStates.EXITED:
                             raise Exception("Target %s exited" % self.name)
 
@@ -77,7 +78,6 @@ def synchronize_state(*states, **kwargs):
             if blocking is True:
                 if not (transition_optional == True and self.state == state):
                     state_reached.wait()
-                avatar.watchmen.remove_watchman('UpdateState', w)
             return ret
 
         return state_synchronizer
@@ -265,7 +265,7 @@ class Target(object):
 
     @watch('TargetCont')
     @action_valid_decorator_factory(TargetStates.STOPPED, 'execution')
-    @synchronize_state(TargetStates.RUNNING, TargetStates.EXITED)
+    @synchronize_state(TargetStates.RUNNING)
     def cont(self, blocking=True):
         """
         Continues the execution of the target


### PR DESCRIPTION
Due to a race condition the example code from intro sometimes threw an exception. 

The execution of the GDB sometimes complets before target.cont() returns. 
Target state thus was EXITED and not RUNNING, as expected by the synchronize_state decorator. 

Rather an edge case as usual binaries tend to run longer, but reason enough to test my own setup ;)

Feedback highly appreciated. 