### PR TITLE
Fixed upstream API change in pygdbmi issue

### DIFF
--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -268,9 +268,7 @@ class GDBProtocol(object):
                 gdb_args += [local_arguments]
 
         self._gdbmi = pygdbmi.gdbcontroller.GdbController(
-            gdb_path=gdb_executable,
-            gdb_args=gdb_args,
-            verbose=verbose)  # set to True for debugging
+            command=[gdb_executable] + gdb_args)
         queue = avatar.queue if avatar is not None else None
         fast_queue = avatar.fast_queue if avatar is not None else None
         self._communicator = GDBResponseListener(


### PR DESCRIPTION
This fixes an issue with pygdbmi for python>=3.5. Pygdbmi changed the API for GDBController: https://github.com/cs01/pygdbmi/commit/449080a084583dc6ee6fd066d453072cf1ed065f#diff-ae02869a0244cfb5070bb2018f718b40L54

Problem with this fix is that the `verbose` argument is not used anymore.