### PR TITLE
Fixed upstream API change in pygdbmi 

### DIFF
--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -268,7 +268,7 @@ class GDBProtocol(object):
                 gdb_args += [local_arguments]
 
         
-        if sys.version_info < (3, 5):
+        if sys.version_info <= (3, 5):
             self._gdbmi = pygdbmi.gdbcontroller.GdbController(
                 gdb_path=gdb_executable,
                 gdb_args=gdb_args,

--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -267,8 +267,15 @@ class GDBProtocol(object):
             if local_arguments is not None:
                 gdb_args += [local_arguments]
 
-        self._gdbmi = pygdbmi.gdbcontroller.GdbController(
-            command=[gdb_executable] + gdb_args)
+        
+        if sys.version_info < (3, 5):
+            self._gdbmi = pygdbmi.gdbcontroller.GdbController(
+                gdb_path=gdb_executable,
+                gdb_args=gdb_args,
+                verbose=verbose)  # set to True for debugging
+        else:
+            self._gdbmi = pygdbmi.gdbcontroller.GdbController(
+                command=[gdb_executable] + gdb_args)
         queue = avatar.queue if avatar is not None else None
         fast_queue = avatar.fast_queue if avatar is not None else None
         self._communicator = GDBResponseListener(

--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -268,9 +268,7 @@ class GDBProtocol(object):
                 gdb_args += [local_arguments]
 
         self._gdbmi = pygdbmi.gdbcontroller.GdbController(
-            gdb_path=gdb_executable,
-            gdb_args=gdb_args,
-            verbose=verbose)  # set to True for debugging
+            command=[gdb_executable] + gdb_args)
         queue = avatar.queue if avatar is not None else None
         fast_queue = avatar.fast_queue if avatar is not None else None
         self._communicator = GDBResponseListener(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
               ],
     install_requires=[
         'pygdbmi==0.9.0.2;python_version<"3.5"',
-        'pygdbmi;python_version>="3.5"',
+        'pygdbmi>=0.10.0.0;python_version>="3.5"',
         'intervaltree',
         'posix_ipc>=1.0.0',
         'capstone>=3.0.4',

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
               'avatar2/installer'
               ],
     install_requires=[
-        'pygdbmi==0.9.0.2;python_version<"3.5"',
-        'pygdbmi>=0.10.0.0;python_version>="3.5"',
+        'pygdbmi==0.9.0.2;python_version<="3.5"',
+        'pygdbmi>=0.10.0.0;python_version>"3.5"',
         'intervaltree',
         'posix_ipc>=1.0.0',
         'capstone>=3.0.4',


### PR DESCRIPTION
This fixes an issue with pygdbmi for python>=3.5. Pygdbmi changed the API for GDBController: cs01/pygdbmi@449080a#diff-ae02869a0244cfb5070bb2018f718b40L54