### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ The following publications describe, use, or extend the avatar² framework:
 
 
 # Acknowledgements
-The avatar² project was partially funded through, and supported by, SIEMENS AG, Corporate Technology.
+The avatar² project was partially funded through, and supported by, SIEMENS AG - Technology.


### PR DESCRIPTION
Siemens had some internal restructuring, "Corporate Technology" got renamed to just "Technology", so rephrasing it to "SIEMENS AG - Technology"