### PR TITLE
Check for active PyPanda target during shutdown

### DIFF
--- a/avatar2/targets/pypanda_target.py
+++ b/avatar2/targets/pypanda_target.py
@@ -26,9 +26,7 @@ class PyPandaTarget(PandaTarget):
         self._thread = None
 
     def shutdown(self):
-
-
-        if self._thread.is_alive():
+        if self._thread is not None and self._thread.is_alive():
             self.protocols.execution.remote_disconnect()
             self.pypanda.end_analysis()
 

--- a/avatar2/targets/pypanda_target.py
+++ b/avatar2/targets/pypanda_target.py
@@ -33,7 +33,8 @@ class PyPandaTarget(PandaTarget):
             # Wait for shutdown
             while self._thread.is_alive():
                 sleep(.01)
-
+                
+        super(PyPandaTarget, self).shutdown()
 
     @watch('TargetInit')
     def init(self, **kwargs):


### PR DESCRIPTION
If Avatar is shutdown or crashes before pypanda target initialization, an exception can occur. Also PyPanda target wasn't calling super shutdown(), leading to POSIX MemoryQueue items, which aren't freed at process exit.