### PR TITLE
Allow docker login in CI to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 - python3 /home/travis/build/$TRAVIS_REPO_SLUG/generate_dockerfile.py --endpoint_list
   avatar-qemu panda --qemu_targets arm-softmmu mips-softmmu
 install:
-- ECHO "$docker_password" | Docker login -u "$DOCKER_USERNAME" --password-stdin || true
+- echo "$docker_password" | docker login -u "$DOCKER_USERNAME" --password-stdin || true
 - docker build --tag avatar2 .
 before_script:
 - docker run -v /home/travis/build/$TRAVIS_REPO_SLUG:/avatar2 --name avatar2 --cap-add=SYS_PTRACE

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 - python3 /home/travis/build/$TRAVIS_REPO_SLUG/generate_dockerfile.py --endpoint_list
   avatar-qemu panda --qemu_targets arm-softmmu mips-softmmu
 install:
-- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+- ECHO "$docker_password" | Docker login -u "$DOCKER_USERNAME" --password-stdin || true
 - docker build --tag avatar2 .
 before_script:
 - docker run -v /home/travis/build/$TRAVIS_REPO_SLUG:/avatar2 --name avatar2 --cap-add=SYS_PTRACE


### PR DESCRIPTION
The login was introduced to work around rate limiting for docker pulls
on dockerhub. However, the required tokens/env variables are not present
for pull requests, resulting into the CI failing. Hence, we now allow
this to be failing, and may need to manually restart CI builds for PRs.

(This commit comes as PR for testing if this workaround-workaround works as expected)