### PR TITLE
Unlink RemoteMemory message queue after opened

### DIFF
--- a/avatar2/protocols/remote_memory.py
+++ b/avatar2/protocols/remote_memory.py
@@ -132,6 +132,7 @@ class RemoteMemoryProtocol(object):
         try:
             self._rx_queue = MessageQueue(self.rx_queue_name, flags=O_RDONLY,
                                           read=True, write=False)
+            self._rx_queue.unlink()
         except Exception as e:
             self.log.exception("Unable to create rx_queue:")
             return False
@@ -139,6 +140,7 @@ class RemoteMemoryProtocol(object):
         try:
             self._tx_queue = MessageQueue(self.tx_queue_name, flags=O_WRONLY,
                                           read=False, write=True)
+            self._tx_queue.unlink()
         except Exception as e:
             self.log.exception("Unable to create tx_queue:")
             self._rx_queue.close()


### PR DESCRIPTION
When using Pypanda/QEMU/Panda with avatar and the POSIX memory queues, if for some reason the memory queue isn't unlinked before the process exits (for example due to a crash), then /dev/mqueue can completely fill up leading to this error message due to ULIMIT:

```
qemu: qemu_avatar_mq_open_read: No space left on device
```
This technically will only happen if the TX/RX queue names are changing, such as when changing the `name` field of the target being spawned to include an identifier, such as PID

```
$ ls /dev/mqueue
EMU34129_tx_queue  EMU41915_tx_queue  EMU44523_tx_queue
EMU36565_rx_queue  EMU42910_rx_queue  EMU45457_rx_queue
...
```
It seems error prone to have to rely on a process itself to clean up at atexit, if it never makes it there. A quick fix is to immediately unlink the queue after it has been connected to by Avatar and after it is created by QEMU. This assumes the queue is for a single connection pair and it will not be reusable as it has been unlinked. Unclear if other clients of remote memory will have issue with this, but since Avatar only supports opening an existing queue instead of creating one, I believe this works out.