### PR TITLE
targets/openocd: pass along multiple scripts

### DIFF
--- a/avatar2/protocols/openocd.py
+++ b/avatar2/protocols/openocd.py
@@ -14,6 +14,7 @@ if sys.version_info < (3, 0):
     import Queue as queue
 else:
     import queue
+from collections.abc import Iterable
 
 from avatar2.targets import TargetStates
 from avatar2.message import AvatarMessage, UpdateStateMessage, BreakpointHitMessage
@@ -52,7 +53,7 @@ class OpenOCDProtocol(Thread):
         """
         if isinstance(openocd_script, str):
             self.openocd_files = [openocd_script]
-        elif isinstance(openocd_script, list):
+        elif isinstance(openocd_script, Iterable):
             self.openocd_files = openocd_script
         else:
             raise TypeError("Wrong type for OpenOCD configuration files")

--- a/avatar2/targets/openocd_target.py
+++ b/avatar2/targets/openocd_target.py
@@ -1,4 +1,5 @@
 import sys
+from collections.abc import Iterable
 
 if sys.version_info < (3, 0):
     from Queue import PriorityQueue
@@ -20,8 +21,16 @@ class OpenOCDTarget(Target):
                  **kwargs
                  ):
 
-        if openocd_script and not os.path.exists(openocd_script):
-            raise ValueError("OpenOCD script %s does not exist!" % openocd_script)
+        if isinstance(openocd_script, str) and not os.path.exists(openocd_script):
+            raise ValueError(f"OpenOCD script {openocd_script} does not exist!")
+        if isinstance(openocd_script, Iterable):
+            missing_scripts = [
+                missing for missing in openocd_script
+                if not os.path.exists(missing)
+            ]
+            if missing_scripts:
+                raise ValueError(f"OpenOCD scripts {missing_scripts} do not exist!")
+
         super(OpenOCDTarget, self).__init__(avatar, **kwargs)
 
         self.executable = (executable if executable is not None


### PR DESCRIPTION
The OpenOCD protocol supports passing multiple scripts if a list is
passed. However, the OpenOCD target checked the path to the script using
os.path.exists(), which does not handle lists of paths.

We now check whether the path is a string or an iterable, and pass that
along. While we're there, we also upgrade the in protocols/openocd.py
to handle more generic iterables instead of `list`.