### PR TITLE
RemoteMemoryProtocol: Handle ImportError on darwin

### DIFF
--- a/avatar2/targets/qemu_target.py
+++ b/avatar2/targets/qemu_target.py
@@ -4,7 +4,10 @@ from os.path import isfile, exists
 
 from avatar2.protocols.gdb import GDBProtocol
 from avatar2.protocols.qmp import QMPProtocol
-from avatar2.protocols.remote_memory import RemoteMemoryProtocol
+try:
+    from avatar2.protocols.remote_memory import RemoteMemoryProtocol
+except ImportError:
+    RemoteMemoryProtocol = None
 from avatar2.targets import Target
 
 from avatar2.installer.config import QEMU, GDB_MULTI
@@ -280,7 +283,7 @@ class QemuTarget(Target):
             i[2].qemu_name
             for i in self._memory_mapping.iter()
             if hasattr(i[2], "qemu_name")
-        ]:
+        ] and RemoteMemoryProtocol is not None:
             rmp = RemoteMemoryProtocol(
                 self._rmem_tx_queue_name,
                 self._rmem_rx_queue_name,


### PR DESCRIPTION
Darwin doesn't have mqueue.h, so the posix_ipc dependency raises an
ImportError when remote_memory.py tries to import MessageQueue.

For now, just fail gracefully, and don't add a rmp to a qemu_target if
RemoteMemoryProtocol can't be imported.