### PR TITLE
Fixed version checking for pygdbmi

### DIFF
--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -1,4 +1,5 @@
 import sys
+from pkg_resources import packaging
 from threading import Thread, Event, Condition
 from struct import pack, unpack
 from codecs import encode
@@ -267,8 +268,8 @@ class GDBProtocol(object):
             if local_arguments is not None:
                 gdb_args += [local_arguments]
 
-
-        if sys.version_info <= (3, 6):
+        # See breaking change in pygdbmi: https://github.com/cs01/pygdbmi/releases
+        if packaging.version.parse(pygdbmi.__version__) < packaging.version.parse("0.10.0.0"):
             self._gdbmi = pygdbmi.gdbcontroller.GdbController(
                 gdb_path=gdb_executable,
                 gdb_args=gdb_args,

--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -294,10 +294,10 @@ class GDBProtocol(object):
         self.shutdown()
 
     def shutdown(self):
-        if self._communicator is not None:
+        if hasattr(self, "_communicator") and self._communicator is not None:
             self._communicator.stop()
             self._communicator = None
-        if self._gdbmi is not None:
+        if hasattr(self, "_gdbmi") and self._gdbmi is not None:
             self._gdbmi.exit()
             self._gdbmi = None
 

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -447,7 +447,7 @@ class Target(object):
         return self.protocols.execution.remove_breakpoint(bkptno)
 
     def update_state(self, state):
-        self.log.info("State changed to to %s" % TargetStates(state))
+        self.log.info("State changed to %s", TargetStates(state))
         self.state = state
 
     @watch('TargetWait')


### PR DESCRIPTION
Version checking for pygdbmi should be for the pygdbmi version, not the Python version. If it tries to use the wrong pygdbmi-version (which has breaking changes) the shutdown method also throws an exception for me. I have fixed this as well.