### PR TITLE
Add UNIX socket support for GDBProtocol and protocol users

### DIFF
--- a/avatar2/protocols/gdb.py
+++ b/avatar2/protocols/gdb.py
@@ -397,6 +397,15 @@ class GDBProtocol(object):
 
         return self._remote_connect_common('%s:%d' % (ip, int(port)))
 
+    def remote_connect_unix(self, unix_path):
+        """
+        connect to a remote gdb server via a UNIX domain socket path
+
+        :param unix_path: path of the UNIX domain socket
+        :returns: True on successful connection
+        """
+        return self._remote_connect_common(unix_path)
+
     def remote_connect_serial(self, device='/dev/ttyACM0', baud_rate=38400,
                               parity='none'):
         """

--- a/avatar2/targets/gdb_target.py
+++ b/avatar2/targets/gdb_target.py
@@ -8,6 +8,7 @@ class GDBTarget(Target):
     def __init__(self, avatar,
                  gdb_executable=None, gdb_additional_args=None, 
                  gdb_ip='127.0.0.1', gdb_port=3333,
+                 gdb_unix_socket_path=None,
                  gdb_serial_device='/dev/ttyACM0',
                  gdb_serial_baud_rate=38400,
                  gdb_serial_parity='none',
@@ -26,6 +27,7 @@ class GDBTarget(Target):
         self.gdb_additional_args = gdb_additional_args if gdb_additional_args else []
         self.gdb_ip = gdb_ip
         self.gdb_port = gdb_port
+        self.gdb_unix_socket_path = gdb_unix_socket_path
         self.gdb_serial_device = gdb_serial_device
         self.gdb_serial_baud_rate = gdb_serial_baud_rate
         self.gdb_serial_parity = gdb_serial_parity
@@ -49,7 +51,12 @@ class GDBTarget(Target):
         # If we are debugging a program locally,
         # we do not need to establish any connections
         if not self._local_binary:
-            if not self._serial:
+            if self.gdb_unix_socket_path is not None:
+                if gdb.remote_connect_unix(self.gdb_unix_socket_path):
+                    self.log.info("Connected to Target")
+                else:
+                    self.log.warning("Connecting failed")
+            elif not self._serial:
                 if gdb.remote_connect(ip=self.gdb_ip, port=self.gdb_port):
                     self.log.info("Connected to Target")
                 else:

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -447,7 +447,7 @@ class Target(object):
         return self.protocols.execution.remove_breakpoint(bkptno)
 
     def update_state(self, state):
-        self.log.info("State changed to to %s" % TargetStates(state))
+        self.log.info("State changed to %s", TargetStates(state))
         self.state = state
 
     @watch('TargetWait')

--- a/tests/test_qemutarget.py
+++ b/tests/test_qemutarget.py
@@ -73,17 +73,18 @@ class FakeTarget(object):
         return True
 
 
-def setup():
+def setup(gdb_unix_socket_path=None):
     global qemu
     global avatar
     global fake_target
 
     arch = setup_ARCH()
 
-    avatar = Avatar(arch=arch, output_directory=test_dir)
+    avatar = Avatar(arch=arch, output_directory=test_dir, configure_logging=False)
     qemu = QemuTarget(avatar, name='qemu_test',
                       #firmware="./tests/binaries/qemu_arm_test",
                       firmware='%s/firmware' % test_dir,
+                      gdb_unix_socket_path=gdb_unix_socket_path,
                       )
     fake_target = FakeTarget()
 
@@ -127,13 +128,22 @@ def teardown():
 
 
 @with_setup(setup, teardown)
-def test_initilization():
+def test_initialization():
     global qemu
 
     qemu.init()
     qemu.wait()
     assert_equal(qemu.state, TargetStates.STOPPED)
 
+@with_setup(lambda: setup(gdb_unix_socket_path="/tmp/test_sock"), teardown)
+def test_initialization_unix():
+    global qemu
+
+    qemu.init()
+    qemu.wait()
+
+    assert_equal(qemu.state, TargetStates.STOPPED)
+    qemu.shutdown()
 
 @with_setup(setup, teardown)
 def test_step():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+import socket
+import threading
+import os
+import time
+
+# oneshot UNIX to TCP socket proxy. Stops after first connection
+def unix2tcp(unix_socket_path, tcp_host, tcp_port):
+    try:
+        os.unlink(unix_socket_path)
+    except OSError:
+        pass
+
+    usock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    tsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    usock.bind(unix_socket_path)
+    usock.listen(1)
+
+    def proxy_loop():
+        uconn, addr = usock.accept()
+        tsock.connect((tcp_host, tcp_port))
+
+        uconn.setblocking(False)
+        tsock.setblocking(False)
+
+        while True:
+            data = None
+
+            try:
+                data = uconn.recv(1000)
+                if len(data) == 0:
+                    break
+                tsock.sendall(data)
+            except BlockingIOError: 
+                pass
+
+            try:
+                data = tsock.recv(1000)
+                if len(data) == 0:
+                    break
+                uconn.sendall(data)
+            except BlockingIOError: 
+                pass
+
+        usock.close()
+        uconn.close()
+        tsock.close()
+
+    threading.Thread(target=proxy_loop, daemon=True).start()
+


### PR DESCRIPTION
This PR adds support for using UNIX sockets for GDB connections instead of TCP. If this PR makes it in, I plan on doing the same for QMP and possibly for the GDBPlugin. The goal is to remove the dependency on port availability, which should remove cross Avatar2 instance contention.

One aspect I didn't consider was where the sockets should be created by default since I use `is not None` to detect if UNIX should be used. Maybe sockets should be automatically placed in the avatar2 output directory (which should be unique per instance), but this would require more invasive changes to the KWArgs for transport selection.

### Testing
hello_world.py, test_gdbprotocol.py, and test_qemutarget.py (ARM) were ran and new tests using the UNIX transport were added.