### PR TITLE
fixing a parsing error

### DIFF
--- a/avatar2/plugins/gdb_memory_map_loader.py
+++ b/avatar2/plugins/gdb_memory_map_loader.py
@@ -26,7 +26,7 @@ def load_memory_mappings(avatar, target, forward=False, update=True):
         raise TypeError("The memory mapping can be loaded ony from GDBTargets")
 
     ret, resp = target.protocols.execution.get_mappings()
-    lines = resp.split("\n")[4:]
+    lines = resp.split("objfile")[-1].split("\n")
     mappings = [
         {
             "start": int(x[0], 16),
@@ -35,7 +35,7 @@ def load_memory_mappings(avatar, target, forward=False, update=True):
             "offset": int(x[3], 16),
             "obj": x[4],
         }
-        for x in [y.split() for y in lines]
+        for x in [y.split() for y in lines if y != ""]
     ]
     memory_ranges = IntervalTree()
 


### PR DESCRIPTION
The parsing assumes a 4 line header, which is removed and assumes to blank line. However, it appears to have blank lines in the output, which causes index out of range errors. 
Solution: 1) splitting on the last part of the header "objfile" to remove unwanted header lines, and then ignoring the blank lines while parsing.

The output to be parsed:

```
 process 502

 Mapped address spaces:


          Start Addr           End Addr       Size     Offset objfile

            0x400000           0x401000     0x1000        0x0 /tests/a.out

      0x7ffe1723f000     0x7ffe17260000    0x21000        0x0 [stack]

      0x7ffe1735c000     0x7ffe17360000     0x4000        0x0 [vvar]

      0x7ffe17360000     0x7ffe17362000     0x2000        0x0 [vdso]

      0xffffffffff600000 0xffffffffff601000     0x1000        0x0 [vsyscall]

```
